### PR TITLE
feat(ci): add verify-packages workflow and gate AUR publish on it

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,6 +2,18 @@
 
 This directory contains GitHub Actions workflows for automating AUR package management.
 
+## Verify packages
+
+`verify-packages.yml` builds each package under `packages/` in an **Arch Linux** container with `makepkg`, installs the resulting archive, and runs light smoke checks (`namcap`, `pacman -Ql`, package-specific file checks).
+
+### Triggers
+
+- **Pull requests** that touch `packages/**`
+- **Manual:** Actions → "Verify packages"
+- **Reusable:** called by **Publish to AUR** before any AUR push
+
+This is not a full `pkgctl` clean chroot, but it catches broken PKGBUILDs, missing sources/files, bad deps, and failed installs before publish.
+
 ## Publish to AUR
 
 `publish-to-aur.yml` copies `packages/<name>/` into the matching AUR git repo and pushes.
@@ -10,6 +22,8 @@ This directory contains GitHub Actions workflows for automating AUR package mana
 
 - **Manual:** Actions → "Publish to AUR" → Run workflow (optional package name, optional dry-run)
 - **Push:** changes under `packages/**` on `master`
+
+Publish always runs **Verify packages** first and skips the AUR push if the build fails.
 
 ### Secrets
 
@@ -25,7 +39,7 @@ This directory contains GitHub Actions workflows for automating AUR package mana
 
 Package → AUR URL mapping lives in `scripts/repo_urls.txt` (defaults to `ssh://aur@aur.archlinux.org/<dir>.git`).
 
-> The older `update-git-packages.yml` / `update-github-packages.yml` workflows still assume the pre-`packages/` layout and nested `*-aur` clones. Prefer this publish workflow until those are rewritten.
+> The older `update-git-packages.yml` / `update-github-packages.yml` workflows still assume the pre-`packages/` layout and nested `*-aur` clones. Prefer verify + publish until those are rewritten.
 
 ## Update Git Packages Workflow
 

--- a/.github/workflows/publish-to-aur.yml
+++ b/.github/workflows/publish-to-aur.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: boolean
         default: false
-  # Publish when package sources land on master (after you merge bumps locally/via PR).
+  # Publish when package sources land on master (after verify succeeds).
   push:
     branches: [master]
     paths:
@@ -34,7 +34,13 @@ env:
   GIT_AUTHOR_EMAIL: brianrobt@pm.me
 
 jobs:
+  verify:
+    uses: ./.github/workflows/verify-packages.yml
+    with:
+      package: ${{ github.event_name == 'workflow_dispatch' && inputs.package || '' }}
+
   publish:
+    needs: verify
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -101,4 +107,5 @@ jobs:
             echo "- **Packages:** ${{ steps.pkgs.outputs.packages }}"
             echo "- **Dry run:** ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}"
             echo "- **Trigger:** ${{ github.event_name }}"
+            echo "- **Verify:** passed (required)"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/verify-packages.yml
+++ b/.github/workflows/verify-packages.yml
@@ -71,18 +71,27 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Build, install, and smoke-test ${{ matrix.package }}
+        id: build
         env:
           PKG: ${{ matrix.package }}
         run: |
           set -euo pipefail
           SRC="$GITHUB_WORKSPACE/packages/$PKG"
+          OUT="$RUNNER_TEMP/verify-$PKG"
           if [ ! -f "$SRC/PKGBUILD" ]; then
             echo "Missing $SRC/PKGBUILD" >&2
             exit 1
           fi
 
+          rm -rf "$OUT"
+          mkdir -p "$OUT"
+
           docker run --rm \
-            -v "$SRC":/pkg \
+            -e HOST_UID="$(id -u)" \
+            -e HOST_GID="$(id -g)" \
+            -e PKG="$PKG" \
+            -v "$SRC":/pkg:ro \
+            -v "$OUT":/out \
             -w /pkg \
             archlinux:latest \
             bash -lc '
@@ -97,7 +106,7 @@ jobs:
               echo "builder ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/builder
               chmod 440 /etc/sudoers.d/builder
 
-              # Work in builder home so makepkg can write freely
+              # Work in builder home so makepkg can write freely (pkg mount is read-only)
               BUILD="/home/builder/pkg"
               rm -rf "$BUILD"
               cp -a /pkg "$BUILD"
@@ -128,7 +137,7 @@ jobs:
               echo "::endgroup::"
 
               echo "::group::smoke test"
-              pacman -Ql "'"$PKG"'"
+              pacman -Ql "$PKG"
               if [ -x /usr/bin/gvm2-setup ]; then
                 test -f /etc/profile.d/gvm2.sh
                 test -d /usr/share/gvm2
@@ -136,10 +145,9 @@ jobs:
               fi
               echo "::endgroup::"
 
-              # Surface results back to the runner for the step summary
-              mkdir -p /pkg/.ci
-              pacman -Ql "'"$PKG"'" >"/pkg/.ci/files.txt"
-              printf "%s\n" "${pkgs[@]}" >"/pkg/.ci/artifacts.txt"
+              pacman -Ql "$PKG" > /out/files.txt
+              printf "%s\n" "${pkgs[@]}" > /out/artifacts.txt
+              chown -R "$HOST_UID:$HOST_GID" /out
             '
 
       - name: Summary
@@ -147,17 +155,17 @@ jobs:
         env:
           PKG: ${{ matrix.package }}
         run: |
+          OUT="$RUNNER_TEMP/verify-$PKG"
           {
             echo "## ${PKG}"
             echo ""
-            if [ -f "packages/$PKG/.ci/artifacts.txt" ]; then
-              echo "- **Artifacts:** $(tr '\n' ' ' < "packages/$PKG/.ci/artifacts.txt")"
+            if [ -f "$OUT/artifacts.txt" ]; then
+              echo "- **Artifacts:** $(tr '\n' ' ' < "$OUT/artifacts.txt")"
               echo "- **Installed files:**"
               echo '```'
-              cat "packages/$PKG/.ci/files.txt"
+              cat "$OUT/files.txt"
               echo '```'
             else
               echo "- **Status:** build failed before summary artifacts were written"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
-          rm -rf "packages/$PKG/.ci"

--- a/.github/workflows/verify-packages.yml
+++ b/.github/workflows/verify-packages.yml
@@ -1,0 +1,163 @@
+name: Verify packages
+
+on:
+  workflow_call:
+    inputs:
+      package:
+        description: "Package under packages/ (empty = all)"
+        required: false
+        type: string
+        default: ''
+  workflow_dispatch:
+    inputs:
+      package:
+        description: "Package under packages/ (empty = all)"
+        required: false
+        type: string
+  pull_request:
+    paths:
+      - 'packages/**'
+      - '.github/workflows/verify-packages.yml'
+
+concurrency:
+  group: verify-packages-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.list.outputs.packages }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+
+      - name: List packages
+        id: list
+        run: |
+          set -euo pipefail
+          INPUT="${{ inputs.package || github.event.inputs.package || '' }}"
+          if [ -n "$INPUT" ]; then
+            if [ ! -f "packages/$INPUT/PKGBUILD" ]; then
+              echo "Package not found: packages/$INPUT/PKGBUILD" >&2
+              exit 1
+            fi
+            PACKAGES=$(jq -cn --arg p "$INPUT" '[$p]')
+          else
+            PACKAGES=$(find packages -mindepth 1 -maxdepth 1 -type d -exec test -f '{}/PKGBUILD' \; -print \
+              | xargs -n1 basename \
+              | sort \
+              | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          fi
+          if [ "$PACKAGES" = "[]" ] || [ -z "$PACKAGES" ]; then
+            echo "No packages found under packages/" >&2
+            exit 1
+          fi
+          echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
+          echo "Building: $PACKAGES"
+
+  build:
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJson(needs.discover.outputs.packages) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+
+      - name: Build, install, and smoke-test ${{ matrix.package }}
+        env:
+          PKG: ${{ matrix.package }}
+        run: |
+          set -euo pipefail
+          SRC="$GITHUB_WORKSPACE/packages/$PKG"
+          if [ ! -f "$SRC/PKGBUILD" ]; then
+            echo "Missing $SRC/PKGBUILD" >&2
+            exit 1
+          fi
+
+          docker run --rm \
+            -v "$SRC":/pkg \
+            -w /pkg \
+            archlinux:latest \
+            bash -lc '
+              set -euo pipefail
+              pacman-key --init
+              pacman-key --populate archlinux
+              pacman -Syu --noconfirm --needed base-devel git sudo namcap
+
+              if ! id builder &>/dev/null; then
+                useradd -m -G wheel builder
+              fi
+              echo "builder ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/builder
+              chmod 440 /etc/sudoers.d/builder
+
+              # Work in builder home so makepkg can write freely
+              BUILD="/home/builder/pkg"
+              rm -rf "$BUILD"
+              cp -a /pkg "$BUILD"
+              chown -R builder:builder "$BUILD"
+              cd "$BUILD"
+
+              echo "::group::namcap PKGBUILD"
+              sudo -u builder namcap PKGBUILD || true
+              echo "::endgroup::"
+
+              echo "::group::makepkg"
+              sudo -u builder makepkg -sf --noconfirm
+              echo "::endgroup::"
+
+              shopt -s nullglob
+              pkgs=(*.pkg.tar.zst)
+              if [ ${#pkgs[@]} -eq 0 ]; then
+                echo "No package archive produced" >&2
+                exit 1
+              fi
+
+              echo "::group::install package"
+              pacman -U --noconfirm "${pkgs[@]}"
+              echo "::endgroup::"
+
+              echo "::group::namcap package"
+              sudo -u builder namcap "${pkgs[@]}" || true
+              echo "::endgroup::"
+
+              echo "::group::smoke test"
+              pacman -Ql "'"$PKG"'"
+              if [ -x /usr/bin/gvm2-setup ]; then
+                test -f /etc/profile.d/gvm2.sh
+                test -d /usr/share/gvm2
+                test -f /usr/share/gvm2/VERSION
+              fi
+              echo "::endgroup::"
+
+              # Surface results back to the runner for the step summary
+              mkdir -p /pkg/.ci
+              pacman -Ql "'"$PKG"'" >"/pkg/.ci/files.txt"
+              printf "%s\n" "${pkgs[@]}" >"/pkg/.ci/artifacts.txt"
+            '
+
+      - name: Summary
+        if: always()
+        env:
+          PKG: ${{ matrix.package }}
+        run: |
+          {
+            echo "## ${PKG}"
+            echo ""
+            if [ -f "packages/$PKG/.ci/artifacts.txt" ]; then
+              echo "- **Artifacts:** $(tr '\n' ' ' < "packages/$PKG/.ci/artifacts.txt")"
+              echo "- **Installed files:**"
+              echo '```'
+              cat "packages/$PKG/.ci/files.txt"
+              echo '```'
+            else
+              echo "- **Status:** build failed before summary artifacts were written"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          rm -rf "packages/$PKG/.ci"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,15 @@ build/
 *-aur/
 *.code-workspace
 .DS_Store
+packages/*/.ci/
+packages/**/pkg
+packages/**/src
+packages/**/*.tar.zst
+packages/**/*.src.tar.*
+packages/**/*.log
+packages/**/*.tar.gz
+packages/**/*.tar.bz2
+packages/**/*.zip
 
 # Dockerfiles for packages I don't maintain
 proton-pass-bin/Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ build/
 *-aur/
 *.code-workspace
 .DS_Store
-packages/*/.ci/
 packages/**/pkg
 packages/**/src
 packages/**/*.tar.zst

--- a/packages/gvm2-git/.SRCINFO
+++ b/packages/gvm2-git/.SRCINFO
@@ -1,17 +1,18 @@
 pkgbase = gvm2-git
 	pkgdesc = Go Version Manager (community reboot of moovweb/gvm)
-	pkgver = 1.1.0.r0.g0000000
+	pkgver = 1.5.0.r0.gb8148b9
 	pkgrel = 1
 	url = https://github.com/brianrobt/gvm2
 	install = gvm2-git.install
 	arch = any
 	license = MIT
+	makedepends = git
 	depends = bash
 	depends = curl
 	depends = git
 	optdepends = bison: required to compile Go from source
 	optdepends = gcc: required to compile Go from source
-	provides = gvm
+	provides = gvm=1.5.0.r0.gb8148b9
 	conflicts = gvm-git
 	source = git+https://github.com/brianrobt/gvm2.git
 	source = gvm2-setup

--- a/packages/gvm2-git/PKGBUILD
+++ b/packages/gvm2-git/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=gvm2-git
 _pkgname=gvm2
-pkgver=1.1.0.r0.g0000000
+pkgver=1.5.0.r0.gb8148b9
 pkgrel=1
 pkgdesc='Go Version Manager (community reboot of moovweb/gvm)'
 arch=('any')
@@ -13,7 +13,7 @@ optdepends=(
   'bison: required to compile Go from source'
   'gcc: required to compile Go from source'
 )
-provides=('gvm')
+provides=("gvm=${pkgver}")
 conflicts=('gvm-git')
 install=gvm2-git.install
 source=(
@@ -23,18 +23,17 @@ source=(
 )
 sha256sums=(
   'SKIP'
-  'SKIP'
-  'SKIP'
+  '72cd6e88680dd24a6986a0e09d4fc5c454acd3fa17a5052916e44afbd14b12b0'
+  '8a14f812c3a9a768320841d1def02a99dcd32e65242ecb0d1aa2ab0e6232ebd5'
 )
 
 pkgver() {
   cd "$_pkgname"
-  local desc
-  if desc=$(git describe --long --tags --abbrev=7 2>/dev/null); then
-    printf '%s' "$(echo "$desc" | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g')"
-  else
-    printf '1.1.0.r%s.g%s' "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
-  fi
+  ( set -o pipefail
+    git describe --long --tags --abbrev=7 2>/dev/null \
+      | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g' \
+      || printf 'r%s.%s' "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
+  )
 }
 
 package() {
@@ -42,7 +41,7 @@ package() {
 
   install -d "$pkgdir/usr/share/$_pkgname"
   cp -a bin binscripts config locales scripts examples \
-    VERSION LICENSE README.md AGENTS.md ChangeLog \
+    VERSION LICENSE README.md ChangeLog \
     "$pkgdir/usr/share/$_pkgname/"
 
   # Placeholder; real user installs go through gvm2-setup into ~/.gvm
@@ -55,6 +54,3 @@ EOF
   install -Dm644 "$srcdir/gvm2.sh" "$pkgdir/etc/profile.d/gvm2.sh"
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }
-sha256sums=('SKIP'
-            '72cd6e88680dd24a6986a0e09d4fc5c454acd3fa17a5052916e44afbd14b12b0'
-            '8a14f812c3a9a768320841d1def02a99dcd32e65242ecb0d1aa2ab0e6232ebd5')


### PR DESCRIPTION
Introduces a reusable `verify-packages.yml` workflow that builds each package under `packages/` inside an Arch Linux container using `makepkg`, installs the resulting archive, and runs smoke checks (`namcap`, `pacman -Ql`, package-specific file checks).

The `publish-to-aur.yml` workflow now calls `verify-packages` as a required prerequisite job, preventing broken PKGBUILDs from being pushed to AUR.

Also updates `gvm2-git` package:
- Bumps `pkgver` to `1.5.0.r0.gb8148b9`
- Adds versioned `provides=("gvm=${pkgver}")` for proper conflict resolution
- Adds `git` to `makedepends`
- Fixes `pkgver()` to use a cleaner pipefail subshell pattern
- Pins `sha256sums` for non-VCS sources
- Removes duplicate `sha256sums` block at end of PKGBUILD
- Drops `AGENTS.md` from installed files

Adds `.gitignore` entries for build artifacts produced by `makepkg` and the CI summary directory to keep the working tree clean.